### PR TITLE
feat: Use inverted images on the website

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
 import { MailIcon } from './icons';
+import invertedLogo from '/images/inverted-logo-horzhi-res.png';
 
 const SocialLink: React.FC<{ href: string; children: React.ReactNode }> = ({ href, children }) => (
   <a href={href} className="w-10 h-10 bg-slate-900/70 border border-slate-700 rounded-lg flex items-center justify-center text-slate-400 hover:text-white hover:border-slate-500 transition-all duration-300">
@@ -17,8 +18,11 @@ export const Footer: React.FC = () => {
         <div className="flex justify-center items-center gap-4 mb-8">
           <SocialLink href="mailto:info@pdiigm.com"><MailIcon /></SocialLink>
         </div>
+        <div className="flex justify-center items-center mb-4">
+          <img src={invertedLogo} alt="Paradiigm LLC" className="h-8" />
+        </div>
         <p className="text-slate-500">
-          © {currentYear} Paradiigm LLC. All rights reserved.
+          © {currentYear} All rights reserved.
         </p>
       </div>
     </footer>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import invertedLogo from '/images/inverted-logo-horzhi-res.png';
 
 const NavLink: React.FC<{ href: string; children: React.ReactNode; onClick?: () => void; isCta?: boolean }> = ({ href, children, onClick, isCta = false }) => (
   <li>
@@ -44,8 +45,7 @@ export const Header: React.FC = () => {
     >
       <div className="container mx-auto px-6 flex justify-between items-center">
         <a href="#" className="flex items-center">
-          <span className="text-3xl text-white mr-2">♾️</span>
-          <span className="text-2xl font-bold text-slate-100">Paradiigm LLC</span>
+          <img src={invertedLogo} alt="Paradiigm LLC" className="h-8" />
         </a>
         <nav className="hidden md:flex items-center">
           <ul className="flex items-center space-x-8">

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import invertedIcon from '/images/inverted-iconhi-res.png';
 
 const Button: React.FC<{ href: string, children: React.ReactNode, variant?: 'primary' | 'secondary' }> = ({ href, children, variant = 'primary' }) => {
   const baseClasses = "px-8 py-3 rounded-lg font-semibold text-lg transition-all duration-300 ease-in-out transform";
@@ -17,6 +18,7 @@ export const Hero: React.FC = () => {
   return (
     <section className="min-h-screen flex items-center justify-center pt-32 pb-12 px-6">
       <div className="text-center max-w-4xl mx-auto opacity-0 animation-fadeInUp">
+        <img src={invertedIcon} alt="Paradiigm Icon" className="h-24 mx-auto mb-8" />
         <h1 className="text-5xl md:text-7xl lg:text-8xl font-extrabold tracking-tighter mb-6 bg-gradient-to-br from-slate-100 to-cyan-400 text-transparent bg-clip-text">
           Infinite Imagination
         </h1>


### PR DESCRIPTION
Replaces the text 'Paradiigm LLC' at the top and bottom of the page with the inverted horizontal logo.

Adds the inverted icon above the 'Infinite Imagination' heading in the hero section.