### PR TITLE
fix: Handle both SVG and image icons in Card component

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,10 +6,11 @@ interface CardProps {
   children: React.ReactNode;
   index: number;
   variant?: 'primary' | 'secondary' | 'tertiary';
-  icon?: string;
+  icon?: React.ReactNode;
+  iconBg?: string;
 }
 
-export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary', icon }) => {
+export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary', icon, iconBg }) => {
   const [ref, isInView] = useInView({ threshold: 0.1, triggerOnce: true });
 
   const getVariantClasses = () => {
@@ -37,8 +38,8 @@ export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary'
       <div className="absolute inset-0 bg-gradient-to-br from-slate-800/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-2xl"></div>
       <div className="relative z-10">
         {icon && (
-            <div className="w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6">
-                <img src={icon} alt="" className="w-full h-full object-contain" />
+            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${iconBg}`}>
+                {typeof icon === 'string' ? <img src={icon} alt="" className="w-full h-full object-contain" /> : icon}
             </div>
         )}
         {children}

--- a/components/ProductsSection.tsx
+++ b/components/ProductsSection.tsx
@@ -85,10 +85,7 @@ export const ProductsSection: React.FC = () => {
     >
       <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
         {products.map((product, index) => (
-          <Card key={product.name} index={index}>
-            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${product.iconBg}`}>
-              {product.icon}
-            </div>
+          <Card key={product.name} index={index} icon={product.icon} iconBg={product.iconBg}>
             <h3 className="text-xl font-bold mb-2 text-slate-100">{product.name}</h3>
             <span className={getStatusChip("Coming Soon")}>
               Coming Soon
@@ -104,7 +101,7 @@ export const ProductsSection: React.FC = () => {
 
       <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
         {buddyApps.map((product, index) => (
-          <Card key={product.name} index={products.length + index} icon={product.icon}>
+          <Card key={product.name} index={products.length + index} icon={product.icon} iconBg={product.iconBg}>
             <h3 className="text-xl font-bold mb-2 text-slate-100">{product.name}</h3>
             <span className={getStatusChip("Coming Soon")}>
               Coming Soon

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,3 +1,0 @@
-
-> paradiigm-llc-website@0.0.0 dev
-> vite


### PR DESCRIPTION
This commit fixes a regression introduced in a previous commit where the icons for the main products were broken.

The `Card` component was refactored to handle both SVG icons (as React components) and image URLs, making it more flexible and preventing this type of error from happening in the future. The `ProductsSection` component was also updated to pass the correct props to the `Card` component for all products.