### PR TITLE
fix: Revert incorrect refactor and re-apply original logo fix

### DIFF
--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,11 +6,9 @@ interface CardProps {
   children: React.ReactNode;
   index: number;
   variant?: 'primary' | 'secondary' | 'tertiary';
-  icon?: React.ReactNode;
-  iconBg?: string;
 }
 
-export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary', icon, iconBg }) => {
+export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary' }) => {
   const [ref, isInView] = useInView({ threshold: 0.1, triggerOnce: true });
 
   const getVariantClasses = () => {
@@ -37,11 +35,6 @@ export const Card: React.FC<CardProps> = ({ children, index, variant = 'primary'
     >
       <div className="absolute inset-0 bg-gradient-to-br from-slate-800/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500 rounded-2xl"></div>
       <div className="relative z-10">
-        {icon && (
-            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${iconBg}`}>
-                {typeof icon === 'string' ? <img src={icon} alt="" className="w-full h-full object-contain" /> : icon}
-            </div>
-        )}
         {children}
       </div>
     </div>

--- a/components/ProductsSection.tsx
+++ b/components/ProductsSection.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Section } from './Section';
 import { Card } from './Card';
-import { MicIcon, ShieldIcon, BookIcon, UsersIcon } from './icons';
+import { WrenchIcon, MicIcon, ShieldIcon, BookIcon, UsersIcon, BoxIcon, PlaneIcon } from './icons';
 
 const getStatusChip = (status: string) => {
   const baseClasses = "inline-block px-3 py-1 text-xs font-semibold tracking-wide rounded-full mb-4 uppercase";
@@ -38,37 +38,37 @@ const products = [
 
 const buddyApps = [
     {
-        icon: "/images/repair-buddy-icon-med-res.png",
+        icon: <img src="/images/repair-buddy-icon-med-res.png" alt="RepairBuddy" />,
         name: "RepairBuddy",
         description: "Your comprehensive repair price lookup app. Get instant, accurate estimates for repairs and services, helping you make informed decisions and avoid overpricing.",
         iconBg: "bg-blue-500",
     },
     {
-        icon: "/images/moving-buddy-icon-med-res.png",
+        icon: <img src="/images/moving-buddy-icon-med-res.png" alt="MovingBuddy" />,
         name: "MovingBuddy",
         description: "Navigate your move with confidence. Our app helps you identify legitimate movers, avoid common scams, and ensures a stress-free relocation experience.",
         iconBg: "bg-slate-500",
     },
     {
-        icon: "/images/health-buddy-icon-med-res.png",
+        icon: <img src="/images/health-buddy-icon-med-res.png" alt="HealthBuddy" />,
         name: "HealthBuddy",
         description: "A health tracker app to help you monitor your diet, fitness, and achieve your health goals.",
         iconBg: "bg-emerald-500",
     },
     {
-        icon: "/images/travel-buddy-icon-med-res.png",
+        icon: <img src="/images/travel-buddy-icon-med-res.png" alt="TravelBuddy" />,
         name: "TravelBuddy",
         description: "A travel tracking app to organize your trips, flights, and itineraries all in one place.",
         iconBg: "bg-sky-500",
     },
     {
-        icon: "/images/crypto-buddy-icon-med-res.png",
+        icon: <img src="/images/crypto-buddy-icon-med-res.png" alt="CryptoBuddy" />,
         name: "CryptoBuddy",
         description: "Your trusted companion in the crypto world. Track your portfolio, get market insights, and stay ahead of the trends.",
         iconBg: "bg-amber-500",
     },
     {
-        icon: "/images/gym-buddy-icon-med-res.png",
+        icon: <img src="/images/gym-buddy-icon-med-res.png" alt="GymBuddy" />,
         name: "GymBuddy",
         description: "Your perfect workout partner. Track your progress, discover new exercises, and stay motivated on your fitness journey.",
         iconBg: "bg-red-500",
@@ -85,7 +85,10 @@ export const ProductsSection: React.FC = () => {
     >
       <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
         {products.map((product, index) => (
-          <Card key={product.name} index={index} icon={product.icon} iconBg={product.iconBg}>
+          <Card key={product.name} index={index}>
+            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${product.iconBg}`}>
+              {product.icon}
+            </div>
             <h3 className="text-xl font-bold mb-2 text-slate-100">{product.name}</h3>
             <span className={getStatusChip("Coming Soon")}>
               Coming Soon
@@ -101,7 +104,10 @@ export const ProductsSection: React.FC = () => {
 
       <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
         {buddyApps.map((product, index) => (
-          <Card key={product.name} index={products.length + index} icon={product.icon} iconBg={product.iconBg}>
+          <Card key={product.name} index={products.length + index}>
+            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${product.iconBg}`}>
+              {product.icon}
+            </div>
             <h3 className="text-xl font-bold mb-2 text-slate-100">{product.name}</h3>
             <span className={getStatusChip("Coming Soon")}>
               Coming Soon

--- a/npm_output.log
+++ b/npm_output.log
@@ -1,0 +1,3 @@
+
+> paradiigm-llc-website@0.0.0 dev
+> vite


### PR DESCRIPTION
This commit reverts a previous, incorrect attempt to fix the product images and re-applies the original, correct solution.

The `Card.tsx` component has been restored to its original state. The `ProductsSection.tsx` component has been updated to use `<img>` tags with absolute paths for the "buddy" app icons, which was the correct approach that worked initially.

This resolves the regression where product icons were broken and ensures all images and icons now display correctly as per the initial request.