### PR TITLE
fix: Remove background colors from buddy app icons and increase size

### DIFF
--- a/components/ProductsSection.tsx
+++ b/components/ProductsSection.tsx
@@ -41,37 +41,31 @@ const buddyApps = [
         icon: <img src="/images/repair-buddy-icon-med-res.png" alt="RepairBuddy" />,
         name: "RepairBuddy",
         description: "Your comprehensive repair price lookup app. Get instant, accurate estimates for repairs and services, helping you make informed decisions and avoid overpricing.",
-        iconBg: "bg-blue-500",
     },
     {
         icon: <img src="/images/moving-buddy-icon-med-res.png" alt="MovingBuddy" />,
         name: "MovingBuddy",
         description: "Navigate your move with confidence. Our app helps you identify legitimate movers, avoid common scams, and ensures a stress-free relocation experience.",
-        iconBg: "bg-slate-500",
     },
     {
         icon: <img src="/images/health-buddy-icon-med-res.png" alt="HealthBuddy" />,
         name: "HealthBuddy",
         description: "A health tracker app to help you monitor your diet, fitness, and achieve your health goals.",
-        iconBg: "bg-emerald-500",
     },
     {
         icon: <img src="/images/travel-buddy-icon-med-res.png" alt="TravelBuddy" />,
         name: "TravelBuddy",
         description: "A travel tracking app to organize your trips, flights, and itineraries all in one place.",
-        iconBg: "bg-sky-500",
     },
     {
         icon: <img src="/images/crypto-buddy-icon-med-res.png" alt="CryptoBuddy" />,
         name: "CryptoBuddy",
         description: "Your trusted companion in the crypto world. Track your portfolio, get market insights, and stay ahead of the trends.",
-        iconBg: "bg-amber-500",
     },
     {
         icon: <img src="/images/gym-buddy-icon-med-res.png" alt="GymBuddy" />,
         name: "GymBuddy",
         description: "Your perfect workout partner. Track your progress, discover new exercises, and stay motivated on your fitness journey.",
-        iconBg: "bg-red-500",
     }
 ];
 
@@ -105,7 +99,7 @@ export const ProductsSection: React.FC = () => {
       <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
         {buddyApps.map((product, index) => (
           <Card key={product.name} index={products.length + index}>
-            <div className={`w-20 h-20 rounded-lg flex items-center justify-center text-white text-3xl mb-6 ${product.iconBg}`}>
+            <div className="w-24 h-24 rounded-lg flex items-center justify-center text-white text-3xl mb-6">
               {product.icon}
             </div>
             <h3 className="text-xl font-bold mb-2 text-slate-100">{product.name}</h3>


### PR DESCRIPTION
This commit removes the background colors from the 'buddy app' icons and increases their size to make them more prominent, as requested by the user.

- The `iconBg` property has been removed from the `buddyApps` data array.
- The size of the icon container has been increased from `w-20 h-20` to `w-24 h-24`.